### PR TITLE
Mute and unmute boosts from account

### DIFF
--- a/Sources/MastodonKit/Models/Relationship.swift
+++ b/Sources/MastodonKit/Models/Relationship.swift
@@ -19,6 +19,8 @@ public struct Relationship {
     public let blocking: Bool
     /// Whether the user is currently muting the account.
     public let muting: Bool
+    /// Whether the user is currently muting boosts from the account.
+    public let mutingBoosts: Bool
     /// Whether the user has requested to follow the account.
     public let requested: Bool
 }
@@ -31,6 +33,7 @@ extension Relationship: JSONDictionaryInitializer {
             let followedBy = dictionary["followed_by"] as? Bool,
             let blocking = dictionary["blocking"] as? Bool,
             let muting = dictionary["muting"] as? Bool,
+            let mutingBoosts = dictionary["muting_boosts"] as? Bool,
             let requested = dictionary["requested"] as? Bool
             else {
                 return nil
@@ -41,6 +44,7 @@ extension Relationship: JSONDictionaryInitializer {
         self.followedBy = followedBy
         self.blocking = blocking
         self.muting = muting
+        self.mutingBoosts = mutingBoosts
         self.requested = requested
     }
 }

--- a/Sources/MastodonKit/Requests/Accounts.swift
+++ b/Sources/MastodonKit/Requests/Accounts.swift
@@ -140,6 +140,22 @@ public struct Accounts {
         return Request<Relationship>(path: "/api/v1/accounts/\(id)/unmute", method: .post(.empty), parse: Request<Relationship>.parser)
     }
 
+    /// Mutes an account's boosts.
+    ///
+    /// - Parameter id: The account id.
+    /// - Returns: Request for `Relationship`.
+    public static func muteBoosts(id: Int) -> Request<Relationship> {
+        return Request<Relationship>(path: "/api/v1/accounts/\(id)/mute_boosts", method: .post(.empty), parse: Request<Relationship>.parser)
+    }
+
+    /// Unmutes an account's boosts.
+    ///
+    /// - Parameter id: The account id.
+    /// - Returns: Request for `Relationship`.
+    public static func unmuteBoosts(id: Int) -> Request<Relationship> {
+        return Request<Relationship>(path: "/api/v1/accounts/\(id)/unmute_boosts", method: .post(.empty), parse: Request<Relationship>.parser)
+    }
+
     /// Gets an account's relationships.
     ///
     /// - Parameter ids: The account's ids.

--- a/Tests/MastodonKitTests/Fixtures/Relationship.json
+++ b/Tests/MastodonKitTests/Fixtures/Relationship.json
@@ -4,5 +4,6 @@
     "followed_by": false,
     "blocking": true,
     "muting": false,
+    "muting_boosts": true,
     "requested": false
 }

--- a/Tests/MastodonKitTests/Fixtures/Relationships.json
+++ b/Tests/MastodonKitTests/Fixtures/Relationships.json
@@ -5,6 +5,7 @@
         "followed_by": false,
         "blocking": true,
         "muting": false,
+        "muting_boosts": true,
         "requested": false
     },
     {
@@ -13,6 +14,7 @@
         "followed_by": false,
         "blocking": true,
         "muting": false,
+        "muting_boosts": true,
         "requested": false
     }
 ]

--- a/Tests/MastodonKitTests/Models/RelationshipTests.swift
+++ b/Tests/MastodonKitTests/Models/RelationshipTests.swift
@@ -13,13 +13,14 @@ class RelationshipTests: XCTestCase {
     func testRelationshipFromJSON() {
         let fixture = try? Fixture.load(fileName: "Fixtures/Relationship.json")
         let dictionary = fixture as! JSONDictionary
-        let relationship = Relationship(from: dictionary)
+        let relationship = Relationship(from: dictionary)!
 
-        XCTAssertEqual(relationship?.id, 42)
-        XCTAssertFalse((relationship?.following)!)
-        XCTAssertFalse((relationship?.followedBy)!)
-        XCTAssertTrue((relationship?.blocking)!)
-        XCTAssertFalse((relationship?.muting)!)
-        XCTAssertFalse((relationship?.requested)!)
+        XCTAssertEqual(relationship.id, 42)
+        XCTAssertFalse(relationship.following)
+        XCTAssertFalse(relationship.followedBy)
+        XCTAssertTrue(relationship.blocking)
+        XCTAssertFalse(relationship.muting)
+        XCTAssertTrue(relationship.mutingBoosts)
+        XCTAssertFalse(relationship.requested)
     }
 }

--- a/Tests/MastodonKitTests/Requests/AccountsTests.swift
+++ b/Tests/MastodonKitTests/Requests/AccountsTests.swift
@@ -307,6 +307,36 @@ class AccountsTests: XCTestCase {
         XCTAssertTrue(type(of: request.parse) == ParserFunctionType<Relationship?>.self)
     }
 
+    func testMuteBoosts() {
+        let request = Accounts.muteBoosts(id: 42)
+
+        // Endpoint
+        XCTAssertEqual(request.path, "/api/v1/accounts/42/mute_boosts")
+
+        // Method
+        XCTAssertEqual(request.method.name, "POST")
+        XCTAssertNil(request.method.queryItems)
+        XCTAssertNil(request.method.httpBody)
+
+        // Parser
+        XCTAssertTrue(type(of: request.parse) == ParserFunctionType<Relationship?>.self)
+    }
+
+    func testUnmuteBoosts() {
+        let request = Accounts.unmuteBoosts(id: 42)
+
+        // Endpoint
+        XCTAssertEqual(request.path, "/api/v1/accounts/42/unmute_boosts")
+
+        // Method
+        XCTAssertEqual(request.method.name, "POST")
+        XCTAssertNil(request.method.queryItems)
+        XCTAssertNil(request.method.httpBody)
+
+        // Parser
+        XCTAssertTrue(type(of: request.parse) == ParserFunctionType<Relationship?>.self)
+    }
+
     func testRelationships() {
         let request = Accounts.relationships(ids: [42, 52])
         let expectedID42 = URLQueryItem(name: "id[]", value: "42")


### PR DESCRIPTION
Cannot be merged because it's not released yet. @Gargron removed the feature from the API documentation [here](https://github.com/tootsuite/documentation/commit/c7fc284a44d39fa2aca96b4f69b7809c03e20c4e#diff-bb117bb0e63810e12cce57962e9b2a4f).