### PR TITLE
Beginning of reworkings for Mastodon 2.0

### DIFF
--- a/Sources/MastodonKit/Models/Account.swift
+++ b/Sources/MastodonKit/Models/Account.swift
@@ -44,7 +44,8 @@ public struct Account {
 extension Account: JSONDictionaryInitializable {
     init?(from dictionary: JSONDictionary) {
         guard
-            let id = dictionary["id"] as? Int,
+            let id = dictionary["id"] as? String,
+            let intID = Int(id),
             let username = dictionary["username"] as? String,
             let acct = dictionary["acct"] as? String,
             let displayName = dictionary["display_name"] as? String,
@@ -64,7 +65,7 @@ extension Account: JSONDictionaryInitializable {
                 return nil
         }
 
-        self.id = id
+        self.id = intID
         self.username = username
         self.acct = acct
         self.displayName = displayName

--- a/Sources/MastodonKit/Models/Attachment.swift
+++ b/Sources/MastodonKit/Models/Attachment.swift
@@ -26,7 +26,8 @@ public struct Attachment {
 extension Attachment: JSONDictionaryInitializable {
     init?(from dictionary: JSONDictionary) {
         guard
-            let id = dictionary["id"] as? Int,
+            let id = dictionary["id"] as? String,
+            let intID = Int(id),
             let typeString = dictionary["type"] as? String,
             let type = AttachmentType(rawValue: typeString),
             let url = dictionary["url"] as? String,
@@ -35,7 +36,7 @@ extension Attachment: JSONDictionaryInitializable {
                 return nil
         }
 
-        self.id = id
+        self.id = intID
         self.type = type
         self.url = url
         self.remoteURL = dictionary["remote_url"] as? String

--- a/Sources/MastodonKit/Models/Notification.swift
+++ b/Sources/MastodonKit/Models/Notification.swift
@@ -24,7 +24,8 @@ public struct Notification {
 extension Notification: JSONDictionaryInitializable {
     init?(from dictionary: JSONDictionary) {
         guard
-            let id = dictionary["id"] as? Int,
+            let id = dictionary["id"] as? String,
+            let intID = Int(id),
             let typeString = dictionary["type"] as? String,
             let type = NotificationType(rawValue: typeString),
             let createdAtString = dictionary["created_at"] as? String,
@@ -35,7 +36,7 @@ extension Notification: JSONDictionaryInitializable {
                 return nil
         }
 
-        self.id = id
+        self.id = intID
         self.type = type
         self.createdAt = createdAt
         self.account = account

--- a/Sources/MastodonKit/Models/Status.swift
+++ b/Sources/MastodonKit/Models/Status.swift
@@ -60,7 +60,8 @@ public struct Status {
 extension Status: JSONDictionaryInitializable {
     init?(from dictionary: JSONDictionary) {
         guard
-            let id = dictionary["id"] as? Int,
+            let id = dictionary["id"] as? String,
+            let intID = Int(id),
             let uri = dictionary["uri"] as? String,
             let urlString = dictionary["url"] as? String,
             let url = URL(string: urlString),
@@ -81,7 +82,7 @@ extension Status: JSONDictionaryInitializable {
                 return nil
         }
 
-        self.id = id
+        self.id = intID
         self.uri = uri
         self.url = url
         self.account = account

--- a/Tests/MastodonKitTests/Fixtures/Account.json
+++ b/Tests/MastodonKitTests/Fixtures/Account.json
@@ -1,5 +1,5 @@
 {
-    "id": 1,
+    "id": "1",
     "username": "ornithocoder",
     "acct": "ornithocoder",
     "display_name": "Ornithologist Coder",

--- a/Tests/MastodonKitTests/Fixtures/Accounts.json
+++ b/Tests/MastodonKitTests/Fixtures/Accounts.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": 1,
+        "id": "1",
         "username": "ornithocoder",
         "acct": "ornithocoder",
         "display_name": "Ornithologist Coder",
@@ -17,7 +17,7 @@
         "statuses_count": 420
     },
     {
-        "id": 2,
+        "id": "2",
         "username": "ornithocoder",
         "acct": "ornithocoder",
         "display_name": "Ornithologist Coder",

--- a/Tests/MastodonKitTests/Fixtures/Attachment.json
+++ b/Tests/MastodonKitTests/Fixtures/Attachment.json
@@ -1,5 +1,5 @@
 {
-    "id": 42,
+    "id": "42",
     "type": "image",
     "url": "http://lorempixel.com/200/200/cats/3/",
     "preview_url": "http://lorempixel.com/200/200/cats/4/",

--- a/Tests/MastodonKitTests/Fixtures/Context.json
+++ b/Tests/MastodonKitTests/Fixtures/Context.json
@@ -1,7 +1,7 @@
 {
     "ancestors": [
         {
-            "id": 1,
+            "id": "1",
             "created_at": "2017-04-06T16:55:02.132Z",
             "in_reply_to_id": null,
             "in_reply_to_account_id": null,
@@ -13,7 +13,7 @@
                 "website": null
             },
             "account": {
-                "id": 2,
+                "id": "2",
                 "username": "ornithocoder",
                 "acct": "ornithocoder",
                 "display_name": "Ornitho Coder",
@@ -45,10 +45,10 @@
     ],
     "descendants": [
         {
-            "id": 1,
+            "id": "1",
             "created_at": "2017-04-06T16:55:02.132Z",
-            "in_reply_to_id": 32,
-            "in_reply_to_account_id": 22,
+            "in_reply_to_id": "32",
+            "in_reply_to_account_id": "22",
             "sensitive": true,
             "spoiler_text": "Let's keep his a secret!",
             "visibility": "public",
@@ -57,7 +57,7 @@
                 "website": "https://mastodon.technology/@ornithocoder"
             },
             "account": {
-                "id": 2,
+                "id": "2",
                 "username": "ornithocoder",
                 "acct": "ornithocoder",
                 "display_name": "Ornitho Coder",

--- a/Tests/MastodonKitTests/Fixtures/Notification.json
+++ b/Tests/MastodonKitTests/Fixtures/Notification.json
@@ -1,9 +1,9 @@
 {
-    "id": 42,
+    "id": "42",
     "type": "favourite",
     "created_at": "2016-12-20T13:14:15.132Z",
     "account": {
-        "id": 1,
+        "id": "1",
         "username": "ornithocoder",
         "acct": "ornithocoder",
         "display_name": "Ornithologist Coder",
@@ -20,7 +20,7 @@
         "statuses_count": 420
     },
     "status": {
-        "id": 1,
+        "id": "1",
         "created_at": "2017-04-06T16:55:02.132Z",
         "in_reply_to_id": null,
         "in_reply_to_account_id": null,
@@ -32,7 +32,7 @@
             "website": null
         },
         "account": {
-            "id": 2,
+            "id": "2",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornitho Coder",

--- a/Tests/MastodonKitTests/Fixtures/Notifications.json
+++ b/Tests/MastodonKitTests/Fixtures/Notifications.json
@@ -1,10 +1,10 @@
 [
     {
-        "id": 42,
+        "id": "42",
         "type": "favourite",
         "created_at": "2016-12-20T13:14:15.132Z",
         "account": {
-            "id": 1,
+            "id": "1",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornithologist Coder",
@@ -21,7 +21,7 @@
             "statuses_count": 420
         },
         "status": {
-            "id": 1,
+            "id": "1",
             "created_at": "2017-04-06T16:55:02.132Z",
             "in_reply_to_id": null,
             "in_reply_to_account_id": null,
@@ -33,7 +33,7 @@
                 "website": null
             },
             "account": {
-                "id": 2,
+                "id": "2",
                 "username": "ornithocoder",
                 "acct": "ornithocoder",
                 "display_name": "Ornitho Coder",
@@ -64,11 +64,11 @@
         }
     },
     {
-        "id": 42,
+        "id": "42",
         "type": "favourite",
         "created_at": "2016-12-20T13:14:15.132Z",
         "account": {
-            "id": 1,
+            "id": "1",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornithologist Coder",
@@ -85,7 +85,7 @@
             "statuses_count": 420
         },
         "status": {
-            "id": 1,
+            "id": "1",
             "created_at": "2017-04-06T16:55:02.132Z",
             "in_reply_to_id": null,
             "in_reply_to_account_id": null,
@@ -97,7 +97,7 @@
                 "website": null
             },
             "account": {
-                "id": 2,
+                "id": "2",
                 "username": "ornithocoder",
                 "acct": "ornithocoder",
                 "display_name": "Ornitho Coder",

--- a/Tests/MastodonKitTests/Fixtures/Results.json
+++ b/Tests/MastodonKitTests/Fixtures/Results.json
@@ -1,7 +1,7 @@
 {
     "accounts": [
         {
-            "id": 1,
+            "id": "1",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornithologist Coder",
@@ -20,10 +20,10 @@
     ],
     "statuses": [
         {
-            "id": 1,
+            "id": "1",
             "created_at": "2017-04-06T16:55:02.132Z",
-            "in_reply_to_id": 32,
-            "in_reply_to_account_id": 22,
+            "in_reply_to_id": "32",
+            "in_reply_to_account_id": "22",
             "sensitive": true,
             "spoiler_text": "Let's keep his a secret!",
             "visibility": "public",
@@ -32,7 +32,7 @@
                 "website": "https://mastodon.technology/@ornithocoder"
             },
             "account": {
-                "id": 2,
+                "id": "2",
                 "username": "ornithocoder",
                 "acct": "ornithocoder",
                 "display_name": "Ornitho Coder",

--- a/Tests/MastodonKitTests/Fixtures/StatusWithNull.json
+++ b/Tests/MastodonKitTests/Fixtures/StatusWithNull.json
@@ -1,5 +1,5 @@
 {
-    "id": 1,
+    "id": "1",
     "created_at": "2017-04-06T16:55:02.132Z",
     "in_reply_to_id": null,
     "in_reply_to_account_id": null,
@@ -11,7 +11,7 @@
         "website": null
     },
     "account": {
-        "id": 2,
+        "id": "2",
         "username": "ornithocoder",
         "acct": "ornithocoder",
         "display_name": "Ornitho Coder",

--- a/Tests/MastodonKitTests/Fixtures/StatusWithoutNull.json
+++ b/Tests/MastodonKitTests/Fixtures/StatusWithoutNull.json
@@ -1,5 +1,5 @@
 {
-    "id": 1,
+    "id": "1",
     "created_at": "2017-04-06T16:55:02.132Z",
     "in_reply_to_id": 32,
     "in_reply_to_account_id": 22,
@@ -11,7 +11,7 @@
         "website": "https://mastodon.technology/@ornithocoder"
     },
     "account": {
-        "id": 2,
+        "id": "2",
         "username": "ornithocoder",
         "acct": "ornithocoder",
         "display_name": "Ornitho Coder",
@@ -36,7 +36,7 @@
     "reblogs_count": 0,
     "favourites_count": 1,
     "reblog": {
-        "id": 1,
+        "id": "1",
         "created_at": "2017-04-06T16:55:02.132Z",
         "in_reply_to_id": null,
         "in_reply_to_account_id": null,
@@ -48,7 +48,7 @@
             "website": null
         },
         "account": {
-            "id": 2,
+            "id": "2",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornitho Coder",

--- a/Tests/MastodonKitTests/Fixtures/Timeline.json
+++ b/Tests/MastodonKitTests/Fixtures/Timeline.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": 1,
+        "id": "1",
         "created_at": "2017-04-06T16:55:02.132Z",
         "in_reply_to_id": 32,
         "in_reply_to_account_id": 22,
@@ -12,7 +12,7 @@
             "website": "https://mastodon.technology/@ornithocoder"
         },
         "account": {
-            "id": 2,
+            "id": "2",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornitho Coder",
@@ -41,7 +41,7 @@
         "language": "fr"
     },
     {
-        "id": 1,
+        "id": "1",
         "created_at": "2017-04-06T16:55:02.132Z",
         "in_reply_to_id": 32,
         "in_reply_to_account_id": 22,
@@ -53,7 +53,7 @@
             "website": "https://mastodon.technology/@ornithocoder"
         },
         "account": {
-            "id": 2,
+            "id": "2",
             "username": "ornithocoder",
             "acct": "ornithocoder",
             "display_name": "Ornitho Coder",


### PR DESCRIPTION
Mastodon 2.0 uses BigInts as Strings in the JSON, hence parsing failing in #30. I'm not sure if this will deal with uploads of attachments etc, correctly, but posting a status without attachments has worked so I'm sure this will to.

I have also updated the tests that gave errors replacing any "id" or "_id" value to String.

I look forward to a pull to main branch soon. :smile:

Also I believe this should warrant a version bump, or Release Candidate, when fully integrated.