### PR TITLE
Add OAuth login API

### DIFF
--- a/Sources/MastodonKit/Requests/Login.swift
+++ b/Sources/MastodonKit/Requests/Login.swift
@@ -35,4 +35,31 @@ public struct Login {
         let method = HTTPMethod.post(.parameters(parameters))
         return Request<LoginSettings>(path: "/oauth/token", method: method)
     }
+
+    /// Completes an OAuth login.
+    ///
+    /// - Parameters:
+    ///   - clientID: The client ID.
+    ///   - clientSecret: The client secret.
+    ///   - scopes: The access scopes.
+    ///   - redirectURI: The client redirectURI.
+    ///   - code: The authorization code.
+    /// - Returns: Request for `LoginSettings`.
+    public static func oauth(clientID: String,
+                              clientSecret: String,
+                              scopes: [AccessScope],
+                              redirectURI: String,
+                              code: String) -> Request<LoginSettings> {
+        let parameters = [
+            Parameter(name: "client_id", value: clientID),
+            Parameter(name: "client_secret", value: clientSecret),
+            Parameter(name: "scope", value: scopes.map(toString).joined(separator: " ")),
+            Parameter(name: "grant_type", value: "authorization_code"),
+            Parameter(name: "redirect_uri", value: redirectURI),
+            Parameter(name: "code", value: code)
+        ]
+
+        let method = HTTPMethod.post(.parameters(parameters))
+        return Request<LoginSettings>(path: "/oauth/token", method: method)
+    }
 }

--- a/Tests/MastodonKitTests/Requests/LoginTests.swift
+++ b/Tests/MastodonKitTests/Requests/LoginTests.swift
@@ -29,4 +29,24 @@ class LoginTests: XCTestCase {
         XCTAssertTrue(payload.contains("username=foo"))
         XCTAssertTrue(payload.contains("password=123"))
     }
+
+    func testOAuthLogin() {
+        let request = Login.oauth(clientID: "client id", clientSecret: "client secret", scopes: [.read, .write], redirectURI: "foo://oauth", code: "123")
+
+        // Endpoint
+        XCTAssertEqual(request.path, "/oauth/token")
+
+        // Method
+        XCTAssertEqual(request.method.name, "POST")
+        XCTAssertNil(request.method.queryItems)
+
+        let payload = String(data: request.method.httpBody!, encoding: .utf8)!
+        XCTAssertEqual(payload.components(separatedBy: "&").count, 6)
+        XCTAssertTrue(payload.contains("client_id=client%20id"))
+        XCTAssertTrue(payload.contains("client_secret=client%20secret"))
+        XCTAssertTrue(payload.contains("scope=read%20write"))
+        XCTAssertTrue(payload.contains("grant_type=authorization_code"))
+        XCTAssertTrue(payload.contains("redirect_uri=foo%3A//oauth"))
+        XCTAssertTrue(payload.contains("code=123"))
+    }
 }


### PR DESCRIPTION
This exposes a new Request `Login.oauth()`.

It's straightforward to perform the user-centric side of OAuth via `ASWebAuthenticationSession`.
This just exposes an API to finish that handshake.