### PR TITLE
making Request.init public

### DIFF
--- a/Sources/MastodonKit/HTTPMethod.swift
+++ b/Sources/MastodonKit/HTTPMethod.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum HTTPMethod {
+public enum HTTPMethod {
     case get(Payload)
     case post(Payload)
     case put(Payload)

--- a/Sources/MastodonKit/Parameter.swift
+++ b/Sources/MastodonKit/Parameter.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Parameter {
+public struct Parameter {
     let name: String
     let value: String?
 }

--- a/Sources/MastodonKit/Payload.swift
+++ b/Sources/MastodonKit/Payload.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum Payload {
+public enum Payload {
     case parameters([Parameter]?)
     case media(MediaAttachment?)
     case empty

--- a/Sources/MastodonKit/Request.swift
+++ b/Sources/MastodonKit/Request.swift
@@ -12,7 +12,7 @@ public struct Request<Model: Codable> {
     let path: String
     let method: HTTPMethod
 
-    init(path: String, method: HTTPMethod = .get(.empty)) {
+    public init(path: String, method: HTTPMethod = .get(.empty)) {
         self.path = path
         self.method = method
     }


### PR DESCRIPTION
I guess that makes more public then you would like, but maybe it's some food for thought.

My problem: I'm trying to get the streaming url from a `Instance`. `Instance` doesn't know about `urls`, so I'm creating my own instance with just a an URLs dict. But now I can't create a `Request` because `init` isn't public. Which basically forces me to rewrite major parts of MastodonKit. I think this could be easier: there should be an easy way to extend MastodonKit without touching the library itself.