### PR TITLE
fixed test

### DIFF
--- a/Sources/MastodonKit/Models/Instance.swift
+++ b/Sources/MastodonKit/Models/Instance.swift
@@ -19,4 +19,6 @@ public class Instance: Codable {
     public let email: String
     /// The Mastodon version used by instance (as of version 1.3).
     public let version: String?
+    /// URLs for Streaming API
+    public let urls: [String: String]?
 }

--- a/Tests/MastodonKitTests/Fixtures/Instance.json
+++ b/Tests/MastodonKitTests/Fixtures/Instance.json
@@ -3,5 +3,6 @@
     "title": "nice title",
     "description": "sweet description",
     "email": "wunderbar email",
-    "version": "1.2.3"
+    "version": "1.2.3",
+    "urls": {"some_url": "somewhere"}
 }

--- a/Tests/MastodonKitTests/Models/InstanceTests.swift
+++ b/Tests/MastodonKitTests/Models/InstanceTests.swift
@@ -19,6 +19,7 @@ class InstanceTests: XCTestCase {
         XCTAssertEqual(instance?.description, "sweet description")
         XCTAssertEqual(instance?.email, "wunderbar email")
         XCTAssertEqual(instance?.version, "1.2.3")
+        XCTAssertEqual(instance?.urls, ["some_url": "somewhere"])
     }
 
     func testInstanceWithInvalidData() {


### PR DESCRIPTION
Added an optional `urls` dict to `Instance`.

This contains the streaming URLs.

I would like to add more properties like `thumbnails` and `languages`, but would like to keep it compatible with the current implementation. What is the best approach?