### PR TITLE
Expose a new Client.oauthAuthorizationURL(…) method

### DIFF
--- a/Sources/MastodonKit/Client.swift
+++ b/Sources/MastodonKit/Client.swift
@@ -60,4 +60,24 @@ public struct Client: ClientType {
 
         task.resume()
     }
+
+    /// OAuth authorization URL. Use this to initiate a standard OAuth login.
+    ///
+    /// - Parameters:
+    ///   - clientID: The client ID.
+    ///   - scopes: The access scopes.
+    ///   - redirectURI: The client redirectURI.
+    /// - Returns: URL for the OAuth authorization endpoint.
+    public func oauthAuthorizationURL(clientID: String, scopes: [AccessScope], redirectURI: String) -> URL? {
+        let parameters = [
+            Parameter(name: "client_id", value: clientID),
+            Parameter(name: "scope", value: scopes.map(toString).joined(separator: " ")),
+            Parameter(name: "redirect_uri", value: redirectURI),
+            Parameter(name: "response_type", value: "code")
+        ]
+
+        let method = HTTPMethod.get(.parameters(parameters))
+        let request = Request<LoginSettings>(path: "/oauth/authorize", method: method)
+        return URLComponents(baseURL: baseURL, request: request)?.url
+    }
 }


### PR DESCRIPTION
This works for my local usage, and I think it could be useful to others - but I'm still working my way through the best way to handle OAuth login on macOS. I'd welcome feedback!

```swift
let client = Client(baseURL: application.baseURL)

guard let tokenURL = client.oauthAuthorizationURL(clientID: application.clientID, scopes: application.scopes, redirectURI: application.redirectURI) else {
    // Handle failure to return a valid token URL
}

NSWorkspace.shared.open(tokenURL)

// Handle the response via your app delegate:

func application(_ application: NSApplication, open urls: [URL]) {
    for url in urls {
        if url.isOAuth2Callback {
            // Pass to Login.oauth(…)
        }
    }
}
```