### PR TITLE
Fix build for Swift 5.1 on Linux

### DIFF
--- a/Sources/MastodonKit/Client.swift
+++ b/Sources/MastodonKit/Client.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import FoundationNetworking
 
 public struct Client: ClientType {
     let baseURL: String

--- a/Sources/MastodonKit/ClientType.swift
+++ b/Sources/MastodonKit/ClientType.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import FoundationNetworking
 
 public protocol ClientType {
     /// The user access token used to perform the network requests.

--- a/Sources/MastodonKit/Foundation/HTTPURLResponse.swift
+++ b/Sources/MastodonKit/Foundation/HTTPURLResponse.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import FoundationNetworking
 
 extension HTTPURLResponse {
     var pagination: Pagination? {

--- a/Sources/MastodonKit/Foundation/URLRequest.swift
+++ b/Sources/MastodonKit/Foundation/URLRequest.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import FoundationNetworking
 
 extension URLRequest {
     init<A>(url: URL, request: Request<A>, accessToken: String?) {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import MastodonKitTests
+
+var tests = [XCTestCaseEntry]()
+tests += MastodonKitTests.allTests()
+XCTMain(tests)


### PR DESCRIPTION
Swift 5.1 moved all of Foundation's networking-related code to a separate module (still included), which you have to include separately with `import FoundationNetworking`. This pull request should do that.

It also adds a Tests/LinuxMain.swift so the package manager doesn't just bail when building on Linux.